### PR TITLE
Ali set value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(OBJ)/%.o: $(SRC)/%.c
 
 clean:
 	$(RM) $(OBJECTS)
-	$(RM) $(OUTPUT)/$(DYNLIB)
+	$(RM) $(OUTPUT)/*
 
 $(LIB_INSTALL):
 	mkdir -p $@
@@ -60,3 +60,6 @@ install: $(LIB_INSTALL) $(INC_INSTALL) $(OUTPUT)/$(DYNLIB)
 
 uninstall:
 	$(RM_REC) $(LIB_INSTALL) $(INC_INSTALL)
+$(OUTPUT)/test_ali:
+	$(CC) test/test_ali.c -L/usr/local/lib/ali -lali -I/usr/local/include/ali -o $(OUTPUT)/test_ali
+test: $(OUTPUT)/test_ali

--- a/include/ali.h
+++ b/include/ali.h
@@ -4,13 +4,19 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <ali_err.h>
+
 struct ali {
-    size_t * _number;
+    size_t *_number;
     size_t _len;
 };
 
-void ali_init(struct ali *self);
+#define ALI_INIT_LIST() (struct ali) { NULL, 0 }
+inline void ali_init(struct ali *self) { *self = ALI_INIT_LIST(); }
 void ali_deinit(struct ali *self);
-void ali_set_value_u64(struct ali *self, uint64_t val);
+ali_err_t ali_set_value_u64(struct ali *self, uint64_t val);
+ali_err_t ali_set_value_u32(struct ali *self, uint32_t val);
+ali_err_t ali_set_value_u16(struct ali *self, uint16_t val);
+ali_err_t ali_set_value_u8(struct ali *self, uint8_t val);
 
 #endif // ALI_H

--- a/include/ali.h
+++ b/include/ali.h
@@ -12,7 +12,7 @@ struct ali {
 };
 
 #define ALI_INIT_LIST() (struct ali) { NULL, 0 }
-inline void ali_init(struct ali *self) { *self = ALI_INIT_LIST(); }
+void ali_init(struct ali *self);
 void ali_deinit(struct ali *self);
 ali_err_t ali_set_value_u64(struct ali *self, uint64_t val);
 ali_err_t ali_set_value_u32(struct ali *self, uint32_t val);

--- a/include/ali.h
+++ b/include/ali.h
@@ -8,8 +8,8 @@ struct ali {
     size_t _len;
 };
 
-void init_ali(struct ali * self);
+void ali_init(struct ali * self);
 
-void deinit_ali(struct ali * self);
+void ali_deinit(struct ali * self);
 
 #endif // ALI_H

--- a/include/ali.h
+++ b/include/ali.h
@@ -2,14 +2,15 @@
 #define ALI_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 struct ali {
     size_t * _number;
     size_t _len;
 };
 
-void ali_init(struct ali * self);
-
-void ali_deinit(struct ali * self);
+void ali_init(struct ali *self);
+void ali_deinit(struct ali *self);
+void ali_set_value_u64(struct ali *self, uint64_t val);
 
 #endif // ALI_H

--- a/include/ali_err.h
+++ b/include/ali_err.h
@@ -1,0 +1,10 @@
+#ifndef ALI_ERR_H
+#define ALI_ERR_H
+
+typedef enum ali_err_t {
+    eALI_ERR_NOERR = 0,
+    eALI_ERR_ALLOCFAIL = -1000,
+} ali_err_t;
+
+#endif // ALI_ERR_H
+

--- a/src/ali.c
+++ b/src/ali.c
@@ -1,11 +1,41 @@
 #include "ali.h"
 #include <stdlib.h>
 
-void ali_init(struct ali * self) {
+#define RATIO_PRIMITIVE_TO_SIZE_T_RU(primitive) \
+    ((sizeof(primitive) / sizeof(size_t)) ? (sizeof(primitive) / sizeof(size_t)) : 1)
+
+void ali_init(struct ali *self) {
     self->_number = NULL;
     self->_len = 0;
 }
 
-void ali_deinit(struct ali * self) {
+void ali_deinit(struct ali *self) {
     free(self->_number);
+}
+
+#define RATIO_U64 RATIO_PRIMITIVE_TO_SIZE_T_RU(uint64_t)
+void ali_set_value_u64(struct ali *self, uint64_t val) {
+    if (self->_number == NULL) {
+        self->_number = malloc(sizeof(size_t) * RATIO_U64);
+        if (self->_number == NULL) {
+            // TODO: this function errored due to a failed malloc call; this should eventually return a value that the calling function can check
+            return;
+        }
+    } else {
+        void *tmp = realloc(self->_number, sizeof(size_t) * RATIO_U64);
+        if (tmp == NULL) {
+            // realloc fail; try malloc
+            free(self->_number);
+            self->_number = malloc(sizeof(size_t) * RATIO_U64);
+            if (self->_number == NULL) {
+                // TODO: add error value for return
+                return;
+            }
+        }
+    }
+    self->_len = RATIO_U64;
+    for (size_t i = 0; i < RATIO_U64; i++) {
+        // reverse index access; set to the value shifted properly and casted (potentially down) to a size_t
+        self->_number[RATIO_U64 - 1 - i] = (size_t) (val >> (8 * i * RATIO_U64));
+    }
 }

--- a/src/ali.c
+++ b/src/ali.c
@@ -1,11 +1,11 @@
 #include "ali.h"
 #include <stdlib.h>
 
-void init_ali(struct ali * self) {
+void ali_init(struct ali * self) {
     self->_number = NULL;
     self->_len = 0;
 }
 
-void deinit_ali(struct ali * self) {
+void ali_deinit(struct ali * self) {
     free(self->_number);
 }

--- a/src/ali.c
+++ b/src/ali.c
@@ -29,7 +29,7 @@ void ali_deinit(struct ali *self) {
     self->_len = RATIO_PRIMITIVE_TO_SIZE_T_RU(type); \
     for (size_t i = 0; i < RATIO_PRIMITIVE_TO_SIZE_T_RU(type); i++) { \
         /* reverse index access; set to the value shifted properly and casted (potentially down) to a size_t */ \
-        self->_number[RATIO_PRIMITIVE_TO_SIZE_T_RU(type) - 1 - i] = (size_t) (val >> (8 * i * RATIO_PRIMITIVE_TO_SIZE_T_RU(type))); \
+        self->_number[RATIO_PRIMITIVE_TO_SIZE_T_RU(type) - 1 - i] = (size_t) (val >> (8 * i * sizeof(size_t))); \
     } \
     return eALI_ERR_NOERR; \
     /*}*/

--- a/src/ali.c
+++ b/src/ali.c
@@ -3,6 +3,10 @@
 
 #include <stdlib.h>
 
+void ali_init(struct ali *self) {
+    *self = ALI_INIT_LIST();
+}
+
 void ali_deinit(struct ali *self) {
     free(self->_number);
 }

--- a/src/ali.c
+++ b/src/ali.c
@@ -1,41 +1,49 @@
 #include "ali.h"
+#include "ali_err.h"
+
 #include <stdlib.h>
-
-#define RATIO_PRIMITIVE_TO_SIZE_T_RU(primitive) \
-    ((sizeof(primitive) / sizeof(size_t)) ? (sizeof(primitive) / sizeof(size_t)) : 1)
-
-void ali_init(struct ali *self) {
-    self->_number = NULL;
-    self->_len = 0;
-}
 
 void ali_deinit(struct ali *self) {
     free(self->_number);
 }
 
-#define RATIO_U64 RATIO_PRIMITIVE_TO_SIZE_T_RU(uint64_t)
-void ali_set_value_u64(struct ali *self, uint64_t val) {
-    if (self->_number == NULL) {
-        self->_number = malloc(sizeof(size_t) * RATIO_U64);
-        if (self->_number == NULL) {
-            // TODO: this function errored due to a failed malloc call; this should eventually return a value that the calling function can check
-            return;
-        }
-    } else {
-        void *tmp = realloc(self->_number, sizeof(size_t) * RATIO_U64);
-        if (tmp == NULL) {
-            // realloc fail; try malloc
-            free(self->_number);
-            self->_number = malloc(sizeof(size_t) * RATIO_U64);
-            if (self->_number == NULL) {
-                // TODO: add error value for return
-                return;
-            }
-        }
-    }
-    self->_len = RATIO_U64;
-    for (size_t i = 0; i < RATIO_U64; i++) {
-        // reverse index access; set to the value shifted properly and casted (potentially down) to a size_t
-        self->_number[RATIO_U64 - 1 - i] = (size_t) (val >> (8 * i * RATIO_U64));
-    }
+#define RATIO_PRIMITIVE_TO_SIZE_T_RU(primitive) \
+    ((sizeof(primitive) / sizeof(size_t)) ? (sizeof(primitive) / sizeof(size_t)) : 1)
+
+#define DEFINE_PRIMITIVE_ALI_SET_VALUE(type) \
+    /*ali_err_t ali_set_value_##typename(struct ali *self, type val) {*/ \
+    if (self->_number == NULL) { \
+        self->_number = malloc(sizeof(size_t) * RATIO_PRIMITIVE_TO_SIZE_T_RU(type)); \
+        if (self->_number == NULL) { \
+            /* malloc fail */ \
+            return eALI_ERR_ALLOCFAIL; \
+        } \
+    } else if (self->_len != RATIO_PRIMITIVE_TO_SIZE_T_RU(type)) { \
+        void *tmp = realloc(self->_number, sizeof(size_t) * RATIO_PRIMITIVE_TO_SIZE_T_RU(type)); \
+        if (tmp == NULL) { \
+            /* realloc fail */ \
+            return eALI_ERR_ALLOCFAIL; \
+        } \
+        self->_number = tmp; \
+    } \
+    self->_len = RATIO_PRIMITIVE_TO_SIZE_T_RU(type); \
+    for (size_t i = 0; i < RATIO_PRIMITIVE_TO_SIZE_T_RU(type); i++) { \
+        /* reverse index access; set to the value shifted properly and casted (potentially down) to a size_t */ \
+        self->_number[RATIO_PRIMITIVE_TO_SIZE_T_RU(type) - 1 - i] = (size_t) (val >> (8 * i * RATIO_PRIMITIVE_TO_SIZE_T_RU(type))); \
+    } \
+    return eALI_ERR_NOERR; \
+    /*}*/
+
+ali_err_t ali_set_value_u64(struct ali *self, uint64_t val) {
+    DEFINE_PRIMITIVE_ALI_SET_VALUE(uint64_t)
 }
+ali_err_t ali_set_value_u32(struct ali *self, uint32_t val) {
+    DEFINE_PRIMITIVE_ALI_SET_VALUE(uint32_t)
+}
+ali_err_t ali_set_value_u16(struct ali *self, uint16_t val) {
+    DEFINE_PRIMITIVE_ALI_SET_VALUE(uint16_t)
+}
+ali_err_t ali_set_value_u8(struct ali *self, uint8_t val) {
+    DEFINE_PRIMITIVE_ALI_SET_VALUE(uint8_t)
+}
+

--- a/test/test_ali.c
+++ b/test/test_ali.c
@@ -1,0 +1,12 @@
+#include <ali.h>
+#include <stdio.h>
+
+int main() {
+    struct ali foo;
+    ali_init(&foo);
+
+    ali_set_value_u64(&foo, 0x123456789abcdef0ULL);
+    printf("ali struct: len - %d, numptr - %p, num - %p\n", foo._len, foo._number, *foo._number);
+
+    return 0;
+}

--- a/test/test_hello.c
+++ b/test/test_hello.c
@@ -1,6 +1,0 @@
-#include "../include/hello.h"
-
-int main() {
-    print_hello();
-    return 0;
-}


### PR DESCRIPTION
This PR adds functions

```
ali_err_t ali_set_value_u64(struct ali*, uint64_t);
ali_err_t ali_set_value_u32(struct ali*, uint32_t);
ali_err_t ali_set_value_u16(struct ali*, uint16_t);
ali_err_t ali_set_value_u8(struct ali*, uint8_t);
```

by utilizing function like macros to implement the same type of thing.

It also adds the enum `ali_err_t` in new file `ali_err.h`